### PR TITLE
Update project for MbedOS 6.12 and higher

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,31 +2,93 @@ on:
   push:
     tags: "v[0-9]+.[0-9]+.[0-9]+**"
     branches: "*"
+  pull_request:
+    branches:
+      - main
+
 jobs:
-  compliation-test:
+  mbed-cli-1-example-compilation-test:
     strategy:
       matrix:
         include:
-          - mbed_os_version: "mbed-os-6.5.0"
-          - mbed_os_version: "mbed-os-6.6.0"
-          - mbed_os_version: "mbed-os-6.7.0"
-          - mbed_os_version: "mbed-os-6.8.0"
-          - mbed_os_version: "mbed-os-6.9.0"
+          - mbed_os_version: "mbed-os-6.12.0"
+          - mbed_os_version: "mbed-os-6.13.0"
     runs-on: ubuntu-latest
-    container: "mbedos/mbed-os-env"
+    container: mbedos/mbed-os-env
     steps:
-      # build demo project
-      - name: Add libraries to project
+
+      - name: Prepare environment
+        run: |
+          echo "MBED_OS_REPO=https://github.com/ARMmbed/mbed-os.git#${{ matrix.mbed_os_version }}" >> "$GITHUB_ENV"
+          echo "CUSTOM_TARGET_REPO=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git#${GITHUB_SHA}" >> "$GITHUB_ENV"
+          echo "CUSTOM_TARGET_NAME=${GITHUB_REPOSITORY##*/TARGET_}" >> "$GITHUB_ENV"
+          echo "CUSTOM_TARGET_DIR=${GITHUB_REPOSITORY##*/}" >> "$GITHUB_ENV"
+          echo "CUSTOM_TARGET_EXAMPLES_DIR=${GITHUB_REPOSITORY##*/}/examples" >> "$GITHUB_ENV"
+          git config --global "http.${GITHUB_SERVER_URL}/.extraheader" "AUTHORIZATION: basic $( echo -n "x-access-token:${{ secrets.GITHUB_TOKEN }}" | base64 )"
+
+      - name: Create and configure demo project
         run: |
           mbed-cli new --create-only .
-          mbed-cli add "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git#${GITHUB_SHA}"
-          mbed-cli add "https://github.com/ARMmbed/mbed-os.git#${{ matrix.mbed_os_version }}"
-      - name: Configure project
+          mbed-cli add "$MBED_OS_REPO"
+          mbed-cli add "$CUSTOM_TARGET_REPO"
+          cp "${CUSTOM_TARGET_DIR}/custom_targets.json" ./
+          mbed conf TARGET "$CUSTOM_TARGET_NAME"
+          mbed conf TOOLCHAIN GCC_ARM
+          echo -e "BUILD\n" > .mbedignore
+          touch main.cpp
+
+      - name: Compile examples
         run: |
-          cp "${GITHUB_REPOSITORY##*/}/custom_targets.json" ./
-          cp "${GITHUB_REPOSITORY##*/}/examples/example_1_blink.cpp" ./
-          (cd mbed-os && mbed releases)
-          mbed conf TARGET BLACKPILL_F401CC
-      # compile project
-      - name: Compile project
-        run: mbed compile --toolchain GCC_ARM --profile debug
+          for CUSTOM_TARGET_EXAMPLE_PATH in $CUSTOM_TARGET_EXAMPLES_DIR/*.cpp; do
+              echo "================================================================================" >&2
+              echo "Compile example $CUSTOM_TARGET_EXAMPLE_PATH" >&2
+              cp "$CUSTOM_TARGET_EXAMPLE_PATH" main.cpp >&2
+              mbed compile --profile debug
+              echo "Complete compilcation succefully" >&2
+          done
+
+
+  mbed-cli-2-example-compilation-test:
+    strategy:
+      matrix:
+        include:
+          - mbed_os_version: "mbed-os-6.12.0"
+          - mbed_os_version: "mbed-os-6.13.0"
+    runs-on: ubuntu-latest
+    container: mbedos/mbed-os-env
+    steps:
+
+      - name: Prepare environment
+        run: |
+          echo "MBED_OS_REPO=https://github.com/ARMmbed/mbed-os.git#${{ matrix.mbed_os_version }}" >> "$GITHUB_ENV"
+          echo "CUSTOM_TARGET_REPO=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git#${GITHUB_SHA}" >> "$GITHUB_ENV"
+          echo "CUSTOM_TARGET_NAME=${GITHUB_REPOSITORY##*/TARGET_}" >> "$GITHUB_ENV"
+          echo "CUSTOM_TARGET_DIR=${GITHUB_REPOSITORY##*/}" >> "$GITHUB_ENV"
+          . "$GITHUB_ENV"
+          echo "CUSTOM_TARGET_DIR_NAME=$(basename "${CUSTOM_TARGET_DIR}")" >> "$GITHUB_ENV"
+          echo "CUSTOM_TARGET_CMAKE_NAME=mbed-$( echo "$CUSTOM_TARGET_NAME" | tr '[A-Z_]' '[a-z-]' )" >> "$GITHUB_ENV"
+          echo "CUSTOM_TARGET_EXAMPLES_DIR=${CUSTOM_TARGET_DIR}/examples" >> "$GITHUB_ENV"
+          git config --global "http.${GITHUB_SERVER_URL}/.extraheader" "AUTHORIZATION: basic $( echo -n "x-access-token:${{ secrets.GITHUB_TOKEN }}" | base64 )"
+          apt-get update && apt-get install -y gawk
+
+      - name: Create and configure demo project
+        run: |
+          mbed-tools new --create-only .
+          echo "$MBED_OS_REPO" > mbed-os.lib
+          echo "$CUSTOM_TARGET_REPO" > "${CUSTOM_TARGET_DIR_NAME}.lib"
+          mbed-tools deploy --force
+          # add custom target to CMakeLists.txt
+          gawk -i inplace -v "target_dir_name=$CUSTOM_TARGET_DIR_NAME" '{ print } /^add_subdirectory/ && !m { print "add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/" target_dir_name ")"; m=1 }' CMakeLists.txt
+          for lib_name in mbed-events "$CUSTOM_TARGET_CMAKE_NAME"; do
+              gawk -i inplace -v "target_lib_name=$lib_name" '{ print } /^target_link_libraries/ && !m { print "target_link_libraries(${APP_TARGET} " target_lib_name ")"; m=1 }' CMakeLists.txt
+          done
+
+      - name: Compile examples
+        run: |
+          for CUSTOM_TARGET_EXAMPLE_PATH in $CUSTOM_TARGET_EXAMPLES_DIR/*.cpp; do
+              echo "================================================================================" >&2
+              echo "Compile example $CUSTOM_TARGET_EXAMPLE_PATH" >&2
+              cp "$CUSTOM_TARGET_EXAMPLE_PATH" main.cpp >&2
+              mbed-tools compile --custom-targets-json "$CUSTOM_TARGET_DIR/custom_targets.json" --profile debug --mbed-target "$CUSTOM_TARGET_NAME" --toolchain GCC_ARM
+              echo "Complete compilcation succefully" >&2
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Make MbedOS v6.12.0 as minimal supported version.
+
+### Added
+- Add support of `mbed-tools`.
+
+### Fixed
+- Adjust target settings to use external clock oscillator.
 
 ## [0.1.1] - 2021-04-11
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_library(mbed-blackpill-f401cc INTERFACE)
+
+target_sources(mbed-blackpill-f401cc
+    INTERFACE
+        PeripheralPins.c
+        system_clock.c
+)
+
+target_include_directories(mbed-blackpill-f401cc
+    INTERFACE
+        .
+)
+
+target_link_libraries(mbed-blackpill-f401cc INTERFACE mbed-stm32f401xc)
+
+# HOTFIX: rename linker script to match name in corresponding CMakeLists.txt file
+set(TARGET_TOOLCHAIN_GCC_ARM_PATH "../mbed-os/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xC/TOOLCHAIN_GCC_ARM")
+if (NOT EXISTS "${TARGET_TOOLCHAIN_GCC_ARM_PATH}/stm32f401xc.ld")
+    file(READ "${TARGET_TOOLCHAIN_GCC_ARM_PATH}/STM32F401XC.ld" TARGET_TOOLCHAIN_GCC_ARM_LD_CONTENT)
+    file(WRITE "${TARGET_TOOLCHAIN_GCC_ARM_PATH}/stm32f401xc.ld" "${TARGET_TOOLCHAIN_GCC_ARM_LD_CONTENT}")
+endif ()

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020, Konstantin Kochin
+Copyright (c) 2021, Konstantin Kochin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PinNames.h
+++ b/PinNames.h
@@ -117,18 +117,19 @@ typedef enum {
 
     // STDIO for console print
 #ifdef MBED_CONF_TARGET_STDIO_UART_TX
-    STDIO_UART_TX = MBED_CONF_TARGET_STDIO_UART_TX,
+    CONSOLE_TX = MBED_CONF_TARGET_STDIO_UART_TX,
 #else
-    STDIO_UART_TX = PA_2,
+    CONSOLE_TX = PA_2,
 #endif
 #ifdef MBED_CONF_TARGET_STDIO_UART_RX
-    STDIO_UART_RX = MBED_CONF_TARGET_STDIO_UART_RX,
+    CONSOLE_RX = MBED_CONF_TARGET_STDIO_UART_RX,
 #else
-    STDIO_UART_RX = PA_3,
+    CONSOLE_RX = PA_3,
 #endif
 
-    USBTX = STDIO_UART_TX, // used for greentea tests
-    USBRX = STDIO_UART_RX, // used for greentea tests
+    // old STDIO pin names for backward compatibility
+    STDIO_UART_TX = CONSOLE_TX,
+    STDIO_UART_RX = CONSOLE_RX,
 
     // I2C signals aliases
     I2C_SDA = PB_6,
@@ -140,13 +141,9 @@ typedef enum {
     SPI_MISO = PA_6,
     SPI_SCK  = PA_5,
 
-    // Standardized LED and button names
-    LED1    = PC_13,
-    //BUTTON1 = NC, // the board have no user buttons
-
     // Backward legacy names
-    USER_BUTTON = NC,
-    //PWM_OUT = PB_5,
+    USER_BUTTON = PA_0,
+    PWM_OUT = D3,
 
     /**** USB FS pins ****/
     USB_OTG_FS_DM = PA_11,
@@ -169,6 +166,10 @@ typedef enum {
     SYS_JTRST = PB_4,
     SYS_WKUP = PA_0,
 } PinName;
+
+// Standardized LED and button names
+#define LED1     PC_13   // LD2 [Green Led]
+#define BUTTON1  PA_0  // B1 [Blue PushButton]
 
 #ifdef __cplusplus
 }

--- a/README.md
+++ b/README.md
@@ -43,21 +43,20 @@ This repository provides Mbed OS 6 support for board with [STM32F401CCU6](https:
 
 ### Default pins
 
-| description | pin |
-|---|---|
+| description | pin | note |
+|---|---|---|
 | STDIO_UART_TX | PA_2 |
 | STDIO_UART_RX | PA_3 |
 | led pin (LED1 alias) | PC_13 |
+| user button pin (BUTTON1 alias) | PA_0 | it may absent on some board revisions. If it presents, `PullUp` mode should be used  |
+
 
 ### Mbed OS version support
 
 | Mbed OS | status |
 |---|---|
-| 6.5 | Compiles and runs ok |
-| 6.6 | Compiles and runs ok, but you need to press reset button (NRST) during firmware uploading. This bug is caused by the pull request [#13777](https://github.com/ARMmbed/mbed-os/pull/13777), but fixed in the [#14032](https://github.com/ARMmbed/mbed-os/pull/14032). |
-| 6.7 | Compiles and runs ok |
-| 6.8 | Compiles and runs ok |
-| 6.9 | Compiles and runs ok |
+| 6.12 | Compiles and runs ok |
+| 6.13 | Compiles and runs ok |
 
 ## Project configuration
 

--- a/custom_targets.json
+++ b/custom_targets.json
@@ -1,43 +1,29 @@
 {
     "BLACKPILL_F401CC": {
         "inherits": [
-            "MCU_STM32"
+            "MCU_STM32F4"
         ],
-        "supported_toolchains": [
-            "GCC_ARM"
-        ],
-        "supported_form_factors": [
-        ],
-        "core": "Cortex-M4F",
         "extra_labels_add": [
-            "STM32F4",
             "STM32F401xC"
         ],
         "macros_add": [
             "STM32F401xC"
         ],
         "config": {
-            "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
-                "macro_name": "CLOCK_SOURCE"
+            "hse_value": {
+                "help": "Explicit HSE value (25MHz)",
+                "value": "25000000",
+                "macro_name": "HSE_VALUE"
             }
+        },
+        "overrides": {
+            "clock_source": "USE_PLL_HSE_XTAL | USE_PLL_HSI",
+            "rtc_clock_source": "USE_RTC_CLK_LSE_OR_LSI",
+            "lse_available": 1
         },
         "detect_code": [
             "1234"
         ],
-        "device_has_add": [
-            "SERIAL_ASYNCH",
-            "FLASH",
-            "MPU"
-        ],
-        "device_name": "STM32F401CCUx",
-        "release_versions": [
-            "5",
-            "6"
-        ],
-        "overrides": {
-            "default-adc-vref": "3.3f"
-        }
+        "device_name": "STM32F401CCUx"
     }
 }

--- a/examples/example_2_button.cpp
+++ b/examples/example_2_button.cpp
@@ -1,0 +1,35 @@
+/**
+ * BlackPill button demo.
+ */
+#include "mbed.h"
+
+DigitalOut user_led(LED1, 1);
+InterruptIn user_button(BUTTON1, PullUp);
+
+void user_button_fall_callback()
+{
+    printf("Button is pressed\n");
+}
+
+void user_button_rise_callback()
+{
+    printf("Button is released\n");
+    for (int i = 0; i < 10; i++) {
+        user_led = !user_led;
+        ThisThread::sleep_for(50ms);
+    }
+}
+
+auto user_button_rise_event = mbed_event_queue()->make_user_allocated_event(user_button_rise_callback);
+auto user_button_fall_event = mbed_event_queue()->make_user_allocated_event(user_button_fall_callback);
+
+int main()
+{
+    user_button.rise(Callback<void()>(&user_button_rise_event, &decltype(user_button_rise_event)::try_call));
+    user_button.fall(Callback<void()>(&user_button_fall_event, &decltype(user_button_fall_event)::try_call));
+    printf("====== Start ======\n");
+
+    while (true) {
+        ThisThread::sleep_for(1s);
+    }
+}

--- a/examples/example_3_adc.cpp
+++ b/examples/example_3_adc.cpp
@@ -1,12 +1,9 @@
 /**
  * BlackPill ADC usage demo.
- *
- * For this example you need a potentiometer (voltage divider), which output/signal pin is connected to PA_0.
  */
 #include "mbed.h"
 
 DigitalOut user_led(LED1, 1);
-AnalogIn user_analog_input(PA_0);
 
 /**
  * Helper STM32F4 specific function to calculate Vref voltage.
@@ -40,57 +37,23 @@ float read_mcu_temperature()
     temp_adc_lsb = ((int32_t)temp_adc_lsb * v_ref_mv) / TEMPSENSOR_CAL_VREFANALOG;
 
     // convert lsb temperature value to degree Celsius
-    temp_value = (float)((temp_adc_lsb - (int32_t)*TEMPSENSOR_CAL1_ADDR) * (TEMPSENSOR_CAL2_TEMP - TEMPSENSOR_CAL1_TEMP)) / (float)(*TEMPSENSOR_CAL2_ADDR - *TEMPSENSOR_CAL1_ADDR) + TEMPSENSOR_CAL1_TEMP;
+    temp_value =
+            (float)((temp_adc_lsb - (int32_t)*TEMPSENSOR_CAL1_ADDR) * (TEMPSENSOR_CAL2_TEMP - TEMPSENSOR_CAL1_TEMP)) /
+            (float)(*TEMPSENSOR_CAL2_ADDR - *TEMPSENSOR_CAL1_ADDR) + TEMPSENSOR_CAL1_TEMP;
 
     return temp_value;
 }
 
-/**
- * Helper function to get formatted float number for case if float number support for printf is disabled.
- */
-void format_fixed_float(char *buf, float f, int precision = 2)
-{
-    int integer_part = f;
-    int temp_digit;
-
-    // write integer part and point
-    buf += sprintf(buf, "%i.", integer_part);
-
-    // write fractional part
-    f -= integer_part;
-    for (int i = 0; i < precision; i++) {
-        f *= 10;
-        temp_digit = f;
-        f -= temp_digit;
-        *buf = temp_digit + '0';
-        buf++;
-    }
-    *buf = '\0';
-}
 
 int main()
 {
-    float v_ref;
     float temp;
-    float user_input;
-    char float_buf[16];
-
     printf("====== Start ======\n");
-
-    // adjust reference voltage of a user analog input
-    v_ref = calculate_reference_voltage();
-    user_analog_input.set_reference_voltage(v_ref);
 
     while (true) {
         // read and show current MCU temperature
         temp = read_mcu_temperature();
-        format_fixed_float(float_buf, temp, 1);
-        printf("MCU temperature:  %s C\n", float_buf);
-
-        // show pin of the user voltage
-        user_input = user_analog_input.read_voltage();
-        format_fixed_float(float_buf, user_input, 2);
-        printf("user pin voltage: %s V\n", float_buf);
+        printf("MCU temperature:  %.1f C\n", temp);
 
         // delay and led blinking
         user_led = 0;


### PR DESCRIPTION
- Make MbedOS v6.12.0 as minimal supported version
- Add mbed cli 2 support
- Adjust target settings to use external clock oscillator